### PR TITLE
Fix variance of ypred

### DIFF
--- a/demos_rstan/lin_std.stan
+++ b/demos_rstan/lin_std.stan
@@ -31,7 +31,7 @@ generated quantities {
   vector[N] mu = mu_std*sd(y) + mean(y);
   real<lower=0> sigma = sigma_std*sd(y);
   // sample from the predictive distribution
-  real ypred = normal_rng((alpha + beta*xpred_std)*sd(y)+mean(y), sigma*sd(y));
+  real ypred = normal_rng((alpha + beta*xpred_std)*sd(y)+mean(y), sigma_std*sd(y));
   // compute log predictive densities to be used for LOO-CV
   // to make appropriate comparison to other models, this log density is computed
   // using the original data scale (y, mu, sigma)

--- a/demos_rstan/lin_std_t.stan
+++ b/demos_rstan/lin_std_t.stan
@@ -33,7 +33,7 @@ generated quantities {
   vector[N] mu = mu_std*sd(y) + mean(y);
   real<lower=0> sigma = sigma_std*sd(y);
   // sample from the predictive distribution
-  real ypred = student_t_rng(nu, (alpha + beta*xpred_std)*sd(y)+mean(y), sigma*sd(y));
+  real ypred = student_t_rng(nu, (alpha + beta*xpred_std)*sd(y)+mean(y), sigma_std*sd(y));
   // compute log predictive densities to be used for LOO-CV
   // to make appropriate comparison to other models, this log density is computed
   // using the original data scale (y, mu, sigma)


### PR DESCRIPTION
ypred was generated using the scaled variance `sigma` multiplied by `sd(y)`, when `sigma_std` should be used, or `sd(y)` omitted.