### PR TITLE
Use cmdstan canonicaliser to update syntax

### DIFF
--- a/demos_rstan/bern.stan
+++ b/demos_rstan/bern.stan
@@ -12,7 +12,7 @@ model {
   y ~ bernoulli(theta); // observation model / likelihood
   // the notation using ~ is syntactic sugar for
   //  target += beta_lpdf(theta | 1, 1);   // lpdf for continuous theta
-
+  // target += bernoulli_lpmf(y | theta); // lpmf for discrete y
   // target is the log density to be sampled
   //
   // y is an array of integers and

--- a/demos_rstan/bern.stan
+++ b/demos_rstan/bern.stan
@@ -1,18 +1,18 @@
 // Bernoulli model
 data {
-  int<lower=0> N;              // number of observations
-  int<lower=0,upper=1> y[N];   // vector of binary observations
+  int<lower=0> N; // number of observations
+  array[N] int<lower=0, upper=1> y; // vector of binary observations
 }
 parameters {
-  real<lower=0,upper=1> theta; // probability of success
+  real<lower=0, upper=1> theta; // probability of success
 }
 model {
   // model block creates the log density to be sampled
-  theta ~ beta(1, 1);          // prior 
-  y ~ bernoulli(theta);        // observation model / likelihood
+  theta ~ beta(1, 1); // prior
+  y ~ bernoulli(theta); // observation model / likelihood
   // the notation using ~ is syntactic sugar for
   //  target += beta_lpdf(theta | 1, 1);   // lpdf for continuous theta
-  //  target += bernoulli_lpmf(y | theta); // lpmf for discrete y
+
   // target is the log density to be sampled
   //
   // y is an array of integers and
@@ -23,6 +23,6 @@ model {
   //  }
   // which is equivalent to
   //  for (i in 1:N) {
-  //    target += bernoulli_lpmf(y[i] | theta); 
+  //    target += bernoulli_lpmf(y[i] | theta);
   //  }
 }

--- a/demos_rstan/binom.stan
+++ b/demos_rstan/binom.stan
@@ -1,15 +1,15 @@
 // Binomial model with beta(1,1) prior
 data {
-  int<lower=0> N;              // number of experiments
-  int<lower=0> y;              // number of successes
+  int<lower=0> N; // number of experiments
+  int<lower=0> y; // number of successes
 }
 parameters {
-  real<lower=0,upper=1> theta; // probability of success in range (0,1)
+  real<lower=0, upper=1> theta; // probability of success in range (0,1)
 }
 model {
   // model block creates the log density to be sampled
-  theta ~ beta(1, 1);          // prior
-  y ~ binomial(N, theta);      // observation model / likelihood
+  theta ~ beta(1, 1); // prior
+  y ~ binomial(N, theta); // observation model / likelihood
   // the notation using ~ is syntactic sugar for
   //  target += beta_lpdf(theta | 1, 1);     // lpdf for continuous theta
   //  target += binomial_lpmf(y | N, theta); // lpmf for discrete y

--- a/demos_rstan/binom2.stan
+++ b/demos_rstan/binom2.stan
@@ -12,7 +12,7 @@ parameters {
 model {
   // model block creates the log density to be sampled
   theta1 ~ beta(1, 1); // prior
-
+  theta2 ~ beta(1, 1); // prior
   y1 ~ binomial(N1, theta1); // observation model / likelihood
   y2 ~ binomial(N2, theta2); // observation model / likelihood
   // the notation using ~ is syntactic sugar for

--- a/demos_rstan/binom2.stan
+++ b/demos_rstan/binom2.stan
@@ -1,20 +1,20 @@
 //  Comparison of two groups with Binomial
 data {
-  int<lower=0> N1;              // number of experiments in group 1
-  int<lower=0> y1;              // number of deaths in group 1
-  int<lower=0> N2;              // number of experiments in group 2
-  int<lower=0> y2;              // number of deaths in group 2
+  int<lower=0> N1; // number of experiments in group 1
+  int<lower=0> y1; // number of deaths in group 1
+  int<lower=0> N2; // number of experiments in group 2
+  int<lower=0> y2; // number of deaths in group 2
 }
 parameters {
-  real<lower=0,upper=1> theta1; // probability of death in group 1
-  real<lower=0,upper=1> theta2; // probability of death in group 2
+  real<lower=0, upper=1> theta1; // probability of death in group 1
+  real<lower=0, upper=1> theta2; // probability of death in group 2
 }
 model {
   // model block creates the log density to be sampled
-  theta1 ~ beta(1, 1);          // prior
-  theta2 ~ beta(1, 1);          // prior
-  y1 ~ binomial(N1, theta1);    // observation model / likelihood
-  y2 ~ binomial(N2, theta2);    // observation model / likelihood
+  theta1 ~ beta(1, 1); // prior
+
+  y1 ~ binomial(N1, theta1); // observation model / likelihood
+  y2 ~ binomial(N2, theta2); // observation model / likelihood
   // the notation using ~ is syntactic sugar for
   //  target += beta_lpdf(theta1 | 1, 1);       // lpdf for continuous theta1
   //  target += beta_lpdf(theta2 | 1, 1);       // lpdf for continuous theta2
@@ -24,5 +24,5 @@ model {
 }
 generated quantities {
   // generated quantities are computed after sampling
-  real oddsratio = (theta2/(1-theta2))/(theta1/(1-theta1));
+  real oddsratio = (theta2 / (1 - theta2)) / (theta1 / (1 - theta1));
 }

--- a/demos_rstan/binomb.stan
+++ b/demos_rstan/binomb.stan
@@ -1,21 +1,21 @@
 // Binomial model with a roughly uniform prior for
 // the probability of success (theta)
 data {
-  int<lower=0> N;              // number of experiments
-  int<lower=0> y;              // number of successes
+  int<lower=0> N; // number of experiments
+  int<lower=0> y; // number of successes
 }
 parameters {
   // sampling is done for the parameters
-  real alpha;                  // logit of probability of success in rang (-Inf,Inf)
+  real alpha; // logit of probability of success in rang (-Inf,Inf)
 }
 transformed parameters {
   // transformed parameters are deterministic transformations of parameters (and data)
-  real theta = inv_logit(alpha); // probability of success in range (0,1)
+
 }
 model {
   // model block creates the log density to be sampled
-  alpha ~ normal(0, 1.5);        // roughly uniform prior for theta
-  y ~ binomial_logit(N, alpha);  // model parameterized with logit of probability
+  alpha ~ normal(0, 1.5); // roughly uniform prior for theta
+  y ~ binomial_logit(N, alpha); // model parameterized with logit of probability
   // the notation using ~ is syntactic sugar for
   //  target += normal_lpdf(alpha | 0, 1.5);       // lpdf for continuous theta
   //  target += binomial_logit_lpmf(y | N, alpha); // lpmf for discrete y

--- a/demos_rstan/binomb.stan
+++ b/demos_rstan/binomb.stan
@@ -10,7 +10,7 @@ parameters {
 }
 transformed parameters {
   // transformed parameters are deterministic transformations of parameters (and data)
-
+  real theta = inv_logit(alpha); // probability of success in range (0,1)
 }
 model {
   // model block creates the log density to be sampled

--- a/demos_rstan/gpareto_functions/gpareto.stan
+++ b/demos_rstan/gpareto_functions/gpareto.stan
@@ -1,61 +1,76 @@
 functions {
   real gpareto_lpdf(vector y, real ymin, real k, real sigma) {
-    // generalised Pareto log pdf 
+    // generalised Pareto log pdf
     int N = rows(y);
     real inv_k = inv(k);
-    if (k<0 && max(y-ymin)/sigma > -inv_k)
-      reject("k<0 and max(y-ymin)/sigma > -1/k; found k, sigma =", k, sigma)
-    if (sigma<=0)
-      reject("sigma<=0; found sigma =", sigma)
-    if (fabs(k) > 1e-15)
-      return -(1+inv_k)*sum(log1p((y-ymin) * (k/sigma))) -N*log(sigma);
-    else
-      return -sum(y-ymin)/sigma -N*log(sigma); // limit k->0
+    if (k < 0 && max(y - ymin) / sigma > -inv_k) {
+      reject("k<0 and max(y-ymin)/sigma > -1/k; found k, sigma =", k, sigma);
+    }
+    if (sigma <= 0) {
+      reject("sigma<=0; found sigma =", sigma);
+    }
+    if (abs(k) > 1e-15) {
+      return -(1 + inv_k) * sum(log1p((y - ymin) * (k / sigma)))
+             - N * log(sigma);
+    } else {
+      return -sum(y - ymin) / sigma - N * log(sigma);
+    } // limit k->0
   }
   real gpareto_cdf(vector y, real ymin, real k, real sigma) {
     // generalised Pareto cdf
     real inv_k = inv(k);
-    if (k<0 && max(y-ymin)/sigma > -inv_k)
-      reject("k<0 and max(y-ymin)/sigma > -1/k; found k, sigma =", k, sigma)
-    if (sigma<=0)
-      reject("sigma<=0; found sigma =", sigma)
-    if (fabs(k) > 1e-15)
-      return exp(sum(log1m_exp((-inv_k)*(log1p((y-ymin) * (k/sigma))))));
-    else
-      return exp(sum(log1m_exp(-(y-ymin)/sigma))); // limit k->0
+    if (k < 0 && max(y - ymin) / sigma > -inv_k) {
+      reject("k<0 and max(y-ymin)/sigma > -1/k; found k, sigma =", k, sigma);
+    }
+    if (sigma <= 0) {
+      reject("sigma<=0; found sigma =", sigma);
+    }
+    if (abs(k) > 1e-15) {
+      return exp(sum(log1m_exp((-inv_k) * log1p((y - ymin) * (k / sigma)))));
+    } else {
+      return exp(sum(log1m_exp(-(y - ymin) / sigma)));
+    } // limit k->0
   }
   real gpareto_lcdf(vector y, real ymin, real k, real sigma) {
     // generalised Pareto log cdf
     real inv_k = inv(k);
-    if (k<0 && max(y-ymin)/sigma > -inv_k)
-      reject("k<0 and max(y-ymin)/sigma > -1/k; found k, sigma =", k, sigma)
-    if (sigma<=0)
-      reject("sigma<=0; found sigma =", sigma)
-    if (fabs(k) > 1e-15)
-      return sum(log1m_exp((-inv_k)*(log1p((y-ymin) * (k/sigma)))));
-    else
-      return sum(log1m_exp(-(y-ymin)/sigma)); // limit k->0
+    if (k < 0 && max(y - ymin) / sigma > -inv_k) {
+      reject("k<0 and max(y-ymin)/sigma > -1/k; found k, sigma =", k, sigma);
+    }
+    if (sigma <= 0) {
+      reject("sigma<=0; found sigma =", sigma);
+    }
+    if (abs(k) > 1e-15) {
+      return sum(log1m_exp((-inv_k) * log1p((y - ymin) * (k / sigma))));
+    } else {
+      return sum(log1m_exp(-(y - ymin) / sigma));
+    } // limit k->0
   }
   real gpareto_lccdf(vector y, real ymin, real k, real sigma) {
     // generalised Pareto log ccdf
     real inv_k = inv(k);
-    if (k<0 && max(y-ymin)/sigma > -inv_k)
-      reject("k<0 and max(y-ymin)/sigma > -1/k; found k, sigma =", k, sigma)
-    if (sigma<=0)
-      reject("sigma<=0; found sigma =", sigma)
-    if (fabs(k) > 1e-15)
-      return (-inv_k)*sum(log1p((y-ymin) * (k/sigma)));
-    else
-      return -sum(y-ymin)/sigma; // limit k->0
+    if (k < 0 && max(y - ymin) / sigma > -inv_k) {
+      reject("k<0 and max(y-ymin)/sigma > -1/k; found k, sigma =", k, sigma);
+    }
+    if (sigma <= 0) {
+      reject("sigma<=0; found sigma =", sigma);
+    }
+    if (abs(k) > 1e-15) {
+      return (-inv_k) * sum(log1p((y - ymin) * (k / sigma)));
+    } else {
+      return -sum(y - ymin) / sigma;
+    } // limit k->0
   }
   real gpareto_rng(real ymin, real k, real sigma) {
     // generalised Pareto rng
-    if (sigma<=0)
-      reject("sigma<=0; found sigma =", sigma)
-    if (fabs(k) > 1e-15)
-      return ymin + (uniform_rng(0,1)^-k -1) * sigma / k;
-    else
-      return ymin - sigma*log(uniform_rng(0,1)); // limit k->0
+    if (sigma <= 0) {
+      reject("sigma<=0; found sigma =", sigma);
+    }
+    if (abs(k) > 1e-15) {
+      return ymin + (uniform_rng(0, 1) ^ -k - 1) * sigma / k;
+    } else {
+      return ymin - sigma * log(uniform_rng(0, 1));
+    } // limit k->0
   }
 }
 data {
@@ -69,8 +84,8 @@ transformed data {
   real ymax = max(y);
 }
 parameters {
-  real<lower=0> sigma; 
-  real<lower=-sigma/(ymax-ymin)> k; 
+  real<lower=0> sigma;
+  real<lower=-sigma / (ymax - ymin)> k;
 }
 model {
   y ~ gpareto(ymin, k, sigma);
@@ -79,10 +94,11 @@ generated quantities {
   vector[N] log_lik;
   vector[N] yrep;
   vector[Nt] predccdf;
-  for (n in 1:N) {
-    log_lik[n] = gpareto_lpdf(rep_vector(y[n],1) | ymin, k, sigma);
+  for (n in 1 : N) {
+    log_lik[n] = gpareto_lpdf(rep_vector(y[n], 1) | ymin, k, sigma);
     yrep[n] = gpareto_rng(ymin, k, sigma);
   }
-  for (nt in 1:Nt)
-    predccdf[nt] = exp(gpareto_lccdf(rep_vector(yt[nt],1) | ymin, k, sigma));
+  for (nt in 1 : Nt) {
+    predccdf[nt] = exp(gpareto_lccdf(rep_vector(yt[nt], 1) | ymin, k, sigma));
+  }
 }

--- a/demos_rstan/grp_aov.stan
+++ b/demos_rstan/grp_aov.stan
@@ -1,16 +1,16 @@
 // Comparison of k groups with common variance (ANOVA)
 data {
-  int<lower=0> N;            // number of observations
-  int<lower=0> K;            // number of groups
-  int<lower=1,upper=K> x[N]; // discrete group indicators
-  vector[N] y;               // real valued observations
+  int<lower=0> N; // number of observations
+  int<lower=0> K; // number of groups
+  array[N] int<lower=1, upper=K> x; // discrete group indicators
+  vector[N] y; // real valued observations
 }
 parameters {
   vector[K] mu;        // group means
   real<lower=0> sigma; // common standard deviation constrained to be positive
 }
 model {
-  mu ~ normal(0, 100);      // weakly informative prior
-  sigma ~ normal(0, 1);     // weakly informative prior
+  mu ~ normal(0, 100); // weakly informative prior
+  sigma ~ normal(0, 1); // weakly informative prior
   y ~ normal(mu[x], sigma); // observation model / likelihood
 }

--- a/demos_rstan/grp_prior_mean.stan
+++ b/demos_rstan/grp_prior_mean.stan
@@ -1,20 +1,20 @@
 // Comparison of k groups with common variance and
 // hierarchical prior for the mean
 data {
-  int<lower=0> N;            // number of observations
-  int<lower=0> K;            // number of groups
-  int<lower=1,upper=K> x[N]; // discrete group indicators
-  vector[N] y;               // real valued observations
+  int<lower=0> N; // number of observations
+  int<lower=0> K; // number of groups
+  array[N] int<lower=1, upper=K> x; // discrete group indicators
+  vector[N] y; // real valued observations
 }
 parameters {
-  real mu0;             // prior mean
+  real mu0; // prior mean
   real<lower=0> sigma0; // prior std constrained to be positive
   vector[K] mu; // group means
-  real<lower=0> sigma;  // common std constrained to be positive
+  real<lower=0> sigma; // common std constrained to be positive
 }
 model {
-  mu0 ~ normal(10, 10);     // weakly informative prior
-  sigma0 ~ normal(0, 10);   // weakly informative prior
+  mu0 ~ normal(10, 10); // weakly informative prior
+  sigma0 ~ normal(0, 10); // weakly informative prior
   mu ~ normal(mu0, sigma0); // population prior with unknown parameters
   // log-normal prior sets normal prior on logarithm of the paremeter,
   // which is useful for positive parameters that shouldn't be very

--- a/demos_rstan/grp_prior_mean_var.stan
+++ b/demos_rstan/grp_prior_mean_var.stan
@@ -1,32 +1,31 @@
-
 // Comparison of k groups with unequal variance and
 // hierarchical priors for the mean and the variance
 data {
   int<lower=0> N; // number of data points
   int<lower=0> K; // number of groups
-  int<lower=1,upper=K> x[N]; // group indicator
+  array[N] int<lower=1, upper=K> x; // group indicator
   vector[N] y; //
 }
 parameters {
-  real mu0;                 // prior mean
-  real<lower=0> musigma0;   // prior std
-  vector[K] mu;             // group means
-  real lsigma0;             // prior mean
-  real<lower=0> lsigma0s;   // prior std
+  real mu0; // prior mean
+  real<lower=0> musigma0; // prior std
+  vector[K] mu; // group means
+  real lsigma0; // prior mean
+  real<lower=0> lsigma0s; // prior std
   vector<lower=0>[K] sigma; // group stds
 }
 model {
-  mu0 ~ normal(10, 10);        // weakly informative prior
-  musigma0 ~ normal(0, 10);    // weakly informative prior
-  mu ~ normal(mu0, musigma0);  // population prior with unknown parameters
+  mu0 ~ normal(10, 10); // weakly informative prior
+  musigma0 ~ normal(0, 10); // weakly informative prior
+  mu ~ normal(mu0, musigma0); // population prior with unknown parameters
   // lsigma0 is prior mean in log scale
-  lsigma0 ~ normal(0, 1);      // weakly informative prior
+  lsigma0 ~ normal(0, 1); // weakly informative prior
   // log-normal prior sets normal prior on logarithm of the paremeter,
   // which is useful for positive parameters that shouldn't be very
   // close to 0. BDA3 Chapter 5 uses scaled inverse Chi^2 prior, but
   // as these don't need to be (semi-)conjugate thinking in terms of
   // log-normal can be easier.
-  lsigma0s ~ lognormal(log(0.1), .5);   // weakly informative prior
+  lsigma0s ~ lognormal(log(0.1), .5); // weakly informative prior
   sigma ~ lognormal(lsigma0, lsigma0s); // population prior with unknown parameters
   y ~ normal(mu[x], sigma[x]); // observation model / likelihood
 }

--- a/demos_rstan/lin.stan
+++ b/demos_rstan/lin.stan
@@ -1,41 +1,42 @@
 // Gaussian linear model with adjustable priors
 data {
   int<lower=0> N; // number of data points
-  vector[N] x;    // covariate / predictor
-  vector[N] y;    // target
-  real xpred;     // new covariate value to make predictions
-  real pmualpha;  // prior mean for alpha
-  real psalpha;   // prior std for alpha
-  real pmubeta;   // prior mean for beta
-  real psbeta;    // prior std for beta
-  real pssigma;   // prior std for half-normal prior for sigma
+  vector[N] x; // covariate / predictor
+  vector[N] y; // target
+  real xpred; // new covariate value to make predictions
+  real pmualpha; // prior mean for alpha
+  real psalpha; // prior std for alpha
+  real pmubeta; // prior mean for beta
+  real psbeta; // prior std for beta
+  real pssigma; // prior std for half-normal prior for sigma
 }
 parameters {
-  real alpha;          // intercept
-  real beta;           // slope
+  real alpha; // intercept
+  real beta; // slope
   real<lower=0> sigma; // standard deviation is constrained to be positive
 }
 transformed parameters {
   // deterministic transformation of parameters and data
-  vector[N] mu = alpha + beta*x;      // linear model
+  vector[N] mu = alpha + beta * x; // linear model
 }
 model {
-  alpha ~ normal(pmualpha, psalpha);  // prior
-  beta ~ normal(pmubeta, psbeta);     // prior
-  sigma ~ normal(0, pssigma);         // as sigma is constrained to be positive,
-                                      // this is same as half-normal prior
-  y ~ normal(mu, sigma);              // observation model / likelihood
+  alpha ~ normal(pmualpha, psalpha); // prior
+  beta ~ normal(pmubeta, psbeta); // prior
+  sigma ~ normal(0, pssigma); // as sigma is constrained to be positive,
+  // this is same as half-normal prior
+  y ~ normal(mu, sigma); // observation model / likelihood
   // the notation using ~ is syntactic sugar for
   //  target += normal_lpdf(alpha | pmualpha, psalpha);
-  //  target += normal_lpdf(beta | pmubeta, psbeta); 
+  //  target += normal_lpdf(beta | pmubeta, psbeta);
   //  target += normal_lpdf(y | mu, sigma);
   // target is the log density to be sampled
 }
 generated quantities {
   // sample from the predictive distribution
-  real ypred = normal_rng(alpha + beta*xpred, sigma);
+  real ypred = normal_rng(alpha + beta * xpred, sigma);
   // compute log predictive densities to be used for LOO-CV
   vector[N] log_lik;
-  for (i in 1:N)
+  for (i in 1 : N) {
     log_lik[i] = normal_lpdf(y[i] | mu[i], sigma);
+  }
 }

--- a/demos_rstan/lin_std.stan
+++ b/demos_rstan/lin_std.stan
@@ -1,41 +1,43 @@
 // Gaussian linear model with standardized data
 data {
   int<lower=0> N; // number of data points
-  vector[N] x;    // covariate / predictor
-  vector[N] y;    // target
-  real xpred;     // new covariate value to make predictions
+  vector[N] x; // covariate / predictor
+  vector[N] y; // target
+  real xpred; // new covariate value to make predictions
 }
 transformed data {
   // deterministic transformations of data
   vector[N] x_std = (x - mean(x)) / sd(x);
   vector[N] y_std = (y - mean(y)) / sd(y);
-  real xpred_std  = (xpred - mean(x)) / sd(x);
+  real xpred_std = (xpred - mean(x)) / sd(x);
 }
 parameters {
-  real alpha;              // intercept
-  real beta;               // slope
+  real alpha; // intercept
+  real beta; // slope
   real<lower=0> sigma_std; // standard deviation is constrained to be positive
 }
 transformed parameters {
   // deterministic transformation of parameters and data
-  vector[N] mu_std = alpha + beta*x_std; // linear model
+  vector[N] mu_std = alpha + beta * x_std; // linear model
 }
 model {
   alpha ~ normal(0, 1); // weakly informative prior (given standardized data)
-  beta ~ normal(0, 1);  // weakly informative prior (given standardized data)
+  beta ~ normal(0, 1); // weakly informative prior (given standardized data)
   sigma_std ~ normal(0, 1); // weakly informative prior (given standardized data)
   y_std ~ normal(mu_std, sigma_std); // observation model / likelihood
 }
 generated quantities {
   // transform to the original data scale
-  vector[N] mu = mu_std*sd(y) + mean(y);
-  real<lower=0> sigma = sigma_std*sd(y);
+  vector[N] mu = mu_std * sd(y) + mean(y);
+  real<lower=0> sigma = sigma_std * sd(y);
   // sample from the predictive distribution
-  real ypred = normal_rng((alpha + beta*xpred_std)*sd(y)+mean(y), sigma_std*sd(y));
+  real ypred = normal_rng((alpha + beta * xpred_std) * sd(y) + mean(y),
+                          sigma_std * sd(y));
   // compute log predictive densities to be used for LOO-CV
   // to make appropriate comparison to other models, this log density is computed
   // using the original data scale (y, mu, sigma)
   vector[N] log_lik;
-  for (i in 1:N)
+  for (i in 1 : N) {
     log_lik[i] = normal_lpdf(y[i] | mu[i], sigma);
+  }
 }

--- a/demos_rstan/lin_std_t.stan
+++ b/demos_rstan/lin_std_t.stan
@@ -1,43 +1,46 @@
 // Linear student-t model
 data {
   int<lower=0> N; // number of data points
-  vector[N] x;    // covariate / predictor
-  vector[N] y;    // target
-  real xpred;     // new covariate value to make predictions
+  vector[N] x; // covariate / predictor
+  vector[N] y; // target
+  real xpred; // new covariate value to make predictions
 }
 transformed data {
   // deterministic transformations of data
   vector[N] x_std = (x - mean(x)) / sd(x);
   vector[N] y_std = (y - mean(y)) / sd(y);
-  real xpred_std  = (xpred - mean(x)) / sd(x);
+  real xpred_std = (xpred - mean(x)) / sd(x);
 }
 parameters {
-  real alpha;          // intercept
-  real beta;           // slope
+  real alpha; // intercept
+  real beta; // slope
   real<lower=0> sigma_std; // standard deviation is constrained to be positive
-  real<lower=1> nu;    // degrees of freedom is constrained >1
+  real<lower=1> nu; // degrees of freedom is constrained >1
 }
 transformed parameters {
   // deterministic transformation of parameters and data
-  vector[N] mu_std = alpha + beta*x_std; // linear model
+  vector[N] mu_std = alpha + beta * x_std; // linear model
 }
 model {
   alpha ~ normal(0, 1); // weakly informative prior (given standardized data)
-  beta ~ normal(0, 1);  // weakly informative prior (given standardized data)
+  beta ~ normal(0, 1); // weakly informative prior (given standardized data)
   sigma_std ~ normal(0, 1); // weakly informative prior (given standardized data)
-  nu ~ gamma(2, 0.1);   // Juárez and Steel(2010)
+  nu ~ gamma(2, 0.1); // Juárez and Steel(2010)
   y_std ~ student_t(nu, mu_std, sigma_std); // observation model / likelihood
 }
 generated quantities {
   // transform to the original data scale
-  vector[N] mu = mu_std*sd(y) + mean(y);
-  real<lower=0> sigma = sigma_std*sd(y);
+  vector[N] mu = mu_std * sd(y) + mean(y);
+  real<lower=0> sigma = sigma_std * sd(y);
   // sample from the predictive distribution
-  real ypred = student_t_rng(nu, (alpha + beta*xpred_std)*sd(y)+mean(y), sigma_std*sd(y));
+  real ypred = student_t_rng(nu,
+                             (alpha + beta * xpred_std) * sd(y) + mean(y),
+                             sigma_std * sd(y));
   // compute log predictive densities to be used for LOO-CV
   // to make appropriate comparison to other models, this log density is computed
   // using the original data scale (y, mu, sigma)
   vector[N] log_lik;
-  for (i in 1:N)
+  for (i in 1 : N) {
     log_lik[i] = student_t_lpdf(y[i] | nu, mu[i], sigma);
+  }
 }

--- a/demos_rstan/poisson_gp.stan
+++ b/demos_rstan/poisson_gp.stan
@@ -1,49 +1,50 @@
 functions {
-  vector gp_pred_rng(vector x2,
-                     vector f1, vector x1,
-                     real alpha, real lscale, real jitter2) {
+  vector gp_pred_rng(vector x2, vector f1, vector x1, real alpha,
+                     real lscale, real jitter2) {
     // rng for predictive distribution of latent values at test locations
     int N1 = rows(x1);
     int N2 = rows(x2);
     vector[N2] f2;
     {
-      matrix[N1, N1] K = cov_exp_quad(to_array_1d(x1), alpha, lscale)
+      matrix[N1, N1] K = gp_exp_quad_cov(to_array_1d(x1), alpha, lscale)
                          + diag_matrix(rep_vector(jitter2, N1));
       matrix[N1, N1] L_K = cholesky_decompose(K);
 
       vector[N1] L_K_div_f1 = mdivide_left_tri_low(L_K, f1);
       vector[N1] K_div_f1 = mdivide_right_tri_low(L_K_div_f1', L_K)';
-      matrix[N1, N2] k_x1_x2 = cov_exp_quad(to_array_1d(x1), to_array_1d(x2), alpha, lscale);
-      vector[N2] f2_mu = (k_x1_x2' * K_div_f1);
+      matrix[N1, N2] k_x1_x2 = gp_exp_quad_cov(to_array_1d(x1),
+                                               to_array_1d(x2), alpha,
+                                               lscale);
+      vector[N2] f2_mu = k_x1_x2' * K_div_f1;
       matrix[N1, N2] v_pred = mdivide_left_tri_low(L_K, k_x1_x2);
-      matrix[N2, N2] cov_f2 = cov_exp_quad(to_array_1d(x2), alpha, lscale) - v_pred' * v_pred + diag_matrix(rep_vector(jitter2, N2));
+      matrix[N2, N2] cov_f2 = gp_exp_quad_cov(to_array_1d(x2), alpha, lscale)
+                              - v_pred' * v_pred
+                              + diag_matrix(rep_vector(jitter2, N2));
       f2 = multi_normal_rng(f2_mu, cov_f2);
     }
     return f2;
   }
 }
-
 data {
   int<lower=1> N;
   vector[N] x;
-  int<lower=0> y[N];
-  real<lower=0> Ey;       // expected count
- 
+  array[N] int<lower=0> y;
+  real<lower=0> Ey; // expected count
+
   int<lower=1> N_predict;
   vector[N_predict] x_predict;
-  
-  real<lower=0> alpha0;   // lscale prior parameter
-  real<lower=0> beta0;    // lscale prior parameter
-}
 
-transformed data { 
-  real jitter2 = 1e-6;    // jitter to stabilize covariance matrices
-  vector[N] xc;           // centered version of x
-  vector[N_predict] xcp;  // centered version of x_predict
+  real<lower=0> alpha0; // lscale prior parameter
+  real<lower=0> beta0; // lscale prior parameter
+}
+transformed data {
+  real jitter2 = 1e-6; // jitter to stabilize covariance matrices
+  vector[N] xc; // centered version of x
+  vector[N_predict] xcp; // centered version of x_predict
   real xmean;
   xmean = mean(x);
-  xc = x-xmean;
-  xcp = x_predict-xmean;
+  xc = x - xmean;
+  xcp = x_predict - xmean;
 }
 parameters {
   real<lower=0> lscale;
@@ -52,24 +53,22 @@ parameters {
   real b;
   vector[N] z;
 }
-
 model {
   vector[N] f;
-  matrix[N, N] cov =   cov_exp_quad(to_array_1d(xc), alpha, lscale)
+  matrix[N, N] cov = gp_exp_quad_cov(to_array_1d(xc), alpha, lscale)
                      + diag_matrix(rep_vector(jitter2, N));
   matrix[N, N] L_cov = cholesky_decompose(cov);
   // non-centered parameterization
-  z ~ normal(0,1);
-  f  = L_cov*z;
+  z ~ normal(0, 1);
+  f = L_cov * z;
   // priors
   lscale ~ inv_gamma(alpha0, beta0);
   alpha ~ normal(0, .5);
   a ~ normal(0, .1);
   b ~ normal(0, .1);
   // observation model
-  y ~ poisson_log(log(Ey) + a + xc*b + f);
+  y ~ poisson_log(log(Ey) + a + xc * b + f);
 }
-
 generated quantities {
   vector[N_predict] mu_predict;
   vector[N_predict] y_predict;
@@ -77,16 +76,19 @@ generated quantities {
   {
     vector[N] f;
     vector[N_predict] f_predict;
-    matrix[N, N] cov = cov_exp_quad(to_array_1d(xc), alpha, lscale)
+    matrix[N, N] cov = gp_exp_quad_cov(to_array_1d(xc), alpha, lscale)
                        + diag_matrix(rep_vector(jitter2, N));
     matrix[N, N] L_cov = cholesky_decompose(cov);
-    f = L_cov*z;
+    f = L_cov * z;
     f_predict = gp_pred_rng(xcp, f, xc, alpha, lscale, jitter2);
-    for (n in 1:N_predict)
-      mu_predict[n] = exp(log(Ey) + a + xcp[n]*b + f_predict[n]);
-    for (n in 1:N_predict)
-      y_predict[n] = poisson_log_rng(log(Ey) + a + xcp[n]*b + f_predict[n]);
-    for (n in 1:N)
-      log_lik[n] = poisson_log_lpmf(y[n] | log(Ey) + a + xc[n]*b + f[n]);
+    for (n in 1 : N_predict) {
+      mu_predict[n] = exp(log(Ey) + a + xcp[n] * b + f_predict[n]);
+    }
+    for (n in 1 : N_predict) {
+      y_predict[n] = poisson_log_rng(log(Ey) + a + xcp[n] * b + f_predict[n]);
+    }
+    for (n in 1 : N) {
+      log_lik[n] = poisson_log_lpmf(y[n] | log(Ey) + a + xc[n] * b + f[n]);
+    }
   }
 }

--- a/demos_rstan/ppc/poisson-hurdle.stan
+++ b/demos_rstan/ppc/poisson-hurdle.stan
@@ -1,57 +1,57 @@
 /* Poisson "hurdle" model (also with upper truncation)
- * 
+ *
  * Note: for simplicity I assume that there is only one way to obtain
- * a zero, as opposed to some zero-inflated models where there are 
- * multiple processes that lead to a zero. So in this example, y is 
+ * a zero, as opposed to some zero-inflated models where there are
+ * multiple processes that lead to a zero. So in this example, y is
  * zero with probability theta and y is modeled as a truncated poisson
  * if greater than zero.
  */
 
 data {
   int<lower=1> N;
-  int<lower=0> y[N];
+  array[N] int<lower=0> y;
 }
 transformed data {
-  int U = max(y);  // upper truncation point
+  int U = max(y); // upper truncation point
 }
 parameters {
-  real<lower=0,upper=1> theta; // Pr(y = 0)
+  real<lower=0, upper=1> theta; // Pr(y = 0)
   real<lower=0> lambda; // Poisson rate parameter (if y > 0)
 }
 model {
   lambda ~ exponential(0.2);
-  
-  for (n in 1:N) {
+
+  for (n in 1 : N) {
     if (y[n] == 0) {
-      target += log(theta);  // log(Pr(y = 0))
+      target += log(theta); // log(Pr(y = 0))
     } else {
-      target += log1m(theta);  // log(Pr(y > 0))
-      y[n] ~ poisson(lambda) T[1,U];  // truncated poisson
+      target += log1m(theta); // log(Pr(y > 0))
+      y[n] ~ poisson(lambda) T[1, U]; // truncated poisson
     }
   }
 }
 generated quantities {
-  real log_lik[N];
-  int y_rep[N];
-  for (n in 1:N) {
+  array[N] real log_lik;
+  array[N] int y_rep;
+  for (n in 1 : N) {
     if (bernoulli_rng(theta)) {
       y_rep[n] = 0;
     } else {
       // use a while loop because Stan doesn't have truncated RNGs
-      int w;  // temporary variable
-      w = poisson_rng(lambda); 
-      while (w == 0 || w > U)
+      int w; // temporary variable
+      w = poisson_rng(lambda);
+      while (w == 0 || w > U) {
         w = poisson_rng(lambda);
-        
+      }
+
       y_rep[n] = w;
     }
     if (y[n] == 0) {
       log_lik[n] = log(theta);
     } else {
-      log_lik[n] = log1m(theta)
-	+ poisson_lpmf(y[n] | lambda)
-	- log_diff_exp(poisson_lcdf(U | lambda),
-                       poisson_lcdf(0 | lambda));
+      log_lik[n] = log1m(theta) + poisson_lpmf(y[n] | lambda)
+                   - log_diff_exp(poisson_lcdf(U | lambda),
+                                  poisson_lcdf(0 | lambda));
     }
   }
 }

--- a/demos_rstan/ppc/poisson-simple.stan
+++ b/demos_rstan/ppc/poisson-simple.stan
@@ -1,6 +1,6 @@
 data {
   int<lower=1> N;
-  int<lower=0> y[N];
+  array[N] int<lower=0> y;
 }
 parameters {
   real<lower=0> lambda;
@@ -10,10 +10,10 @@ model {
   y ~ poisson(lambda);
 }
 generated quantities {
-  real log_lik[N];
-  int y_rep[N];
-  for (n in 1:N) {
+  array[N] real log_lik;
+  array[N] int y_rep;
+  for (n in 1 : N) {
     y_rep[n] = poisson_rng(lambda);
     log_lik[n] = poisson_lpmf(y[n] | lambda);
-    }
+  }
 }


### PR DESCRIPTION
@avehtari It looks like the canonicaliser also made some updates to spacing and adding braces to `if` statements. Let me know if you don't want those changes as well, and I can revert.

New syntax checked for correctness via:
```r
stan_files <- list.files(".",pattern=".stan$",recursive=TRUE)

purrr::walk(stan_files, \(stan_file) {
    cmdstan_mod <- cmdstanr::cmdstan_model(stan_file, compile = FALSE)
    cmdstan_mod$check_syntax()
})
```